### PR TITLE
Optional message delivery delay

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -335,7 +335,8 @@ func (c *Consumer) generateQuery() string {
 			sb.WriteString(` created_at >= CURRENT_TIMESTAMP - $3::interval AND`)
 			sb.WriteString(` created_at < CURRENT_TIMESTAMP AND`)
 		}
-		sb.WriteString(` (locked_until IS NULL OR locked_until < CURRENT_TIMESTAMP)`)
+		sb.WriteString(` (locked_until IS NULL OR locked_until < CURRENT_TIMESTAMP) AND`)
+		sb.WriteString(` delayed_until < CURRENT_TIMESTAMP`)
 		if c.cfg.MaxConsumeCount > 0 {
 			sb.WriteString(` AND consumed_count < `)
 			sb.WriteString(strconv.FormatUint(uint64(c.cfg.MaxConsumeCount), 10))

--- a/message.go
+++ b/message.go
@@ -29,6 +29,8 @@ type MessageOutgoing struct {
 	Metadata Metadata
 	// Payload is the message's Payload.
 	Payload json.RawMessage
+	// Delay (seconds) is the time when the message should become visible in the queue.
+	Delay int
 }
 
 // MessageIncoming is a record retrieved from table queue in Postgres

--- a/x/schema/queue.go
+++ b/x/schema/queue.go
@@ -14,6 +14,7 @@ func GenerateCreateTableQuery(queueName string) string {
 	(
 		id             UUID        DEFAULT gen_random_uuid() NOT NULL PRIMARY KEY,
 		created_at     TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
+		delayed_until  TIMESTAMPTZ                           NULL,
 		started_at     TIMESTAMPTZ                           NULL,
 		locked_until   TIMESTAMPTZ                           NULL,
 		processed_at   TIMESTAMPTZ                           NULL,


### PR DESCRIPTION
In some cases you may need delay message before it become available.
In my usecase I need periodicaly ask external service if state has changed in approximately 60 second intervals until I get the result (error or success).  

This is similar approach to "Azure service bus - Scheduled delivery"
https://learn.microsoft.com/en-us/azure/service-bus-messaging/advanced-features-overview

I've used "Delay" instead "Schedule" because this way I can use SQL server time. 
SQL and App can be on different servers with slightly different time (seconds, sometimes minutes) in case of issues with server timeSync and message queue is pretty time sensitive thing so I would say "same timesource policy" should be applied. 
Schedule to exact time is still possible by calculating "seconds to" ( t2.Sub(t1) ) on App server


