### PR TITLE
optional message delivery delay

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -335,7 +335,8 @@ func (c *Consumer) generateQuery() string {
 			sb.WriteString(` created_at >= CURRENT_TIMESTAMP - $3::interval AND`)
 			sb.WriteString(` created_at < CURRENT_TIMESTAMP AND`)
 		}
-		sb.WriteString(` (locked_until IS NULL OR locked_until < CURRENT_TIMESTAMP)`)
+		sb.WriteString(` (locked_until IS NULL OR locked_until < CURRENT_TIMESTAMP) AND`)
+		sb.WriteString(` delayed_until < CURRENT_TIMESTAMP`)
 		if c.cfg.MaxConsumeCount > 0 {
 			sb.WriteString(` AND consumed_count < `)
 			sb.WriteString(strconv.FormatUint(uint64(c.cfg.MaxConsumeCount), 10))

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -23,7 +23,7 @@ func TestConsumer_generateQuery(t *testing.T) {
 		{
 			name: "simple",
 			args: args{queueName: "testing_queue"},
-			want: "UPDATE \"testing_queue\" SET locked_until = $1, started_at = CURRENT_TIMESTAMP, consumed_count = consumed_count+1 WHERE id IN (SELECT id FROM \"testing_queue\" WHERE (locked_until IS NULL OR locked_until < CURRENT_TIMESTAMP) AND consumed_count < 3 AND processed_at IS NULL ORDER BY consumed_count ASC, created_at ASC LIMIT $2 FOR UPDATE SKIP LOCKED) RETURNING id, payload, metadata, consumed_count, locked_until",
+			want: "UPDATE \"testing_queue\" SET locked_until = $1, started_at = CURRENT_TIMESTAMP, consumed_count = consumed_count+1 WHERE id IN (SELECT id FROM \"testing_queue\" WHERE (locked_until IS NULL OR locked_until < CURRENT_TIMESTAMP) AND delayed_until < CURRENT_TIMESTAMP AND consumed_count < 3 AND processed_at IS NULL ORDER BY consumed_count ASC, created_at ASC LIMIT $2 FOR UPDATE SKIP LOCKED) RETURNING id, payload, metadata, consumed_count, locked_until",
 		},
 		{
 			name: "scanInterval 12 hours",
@@ -34,7 +34,7 @@ func TestConsumer_generateQuery(t *testing.T) {
 					WithHistoryLimit(12 * time.Hour),
 				},
 			},
-			want: "UPDATE \"testing_queue\" SET locked_until = $1, started_at = CURRENT_TIMESTAMP, consumed_count = consumed_count+1 WHERE id IN (SELECT id FROM \"testing_queue\" WHERE created_at >= CURRENT_TIMESTAMP - $3::interval AND created_at < CURRENT_TIMESTAMP AND (locked_until IS NULL OR locked_until < CURRENT_TIMESTAMP) AND consumed_count < 3 AND processed_at IS NULL ORDER BY consumed_count ASC, created_at ASC LIMIT $2 FOR UPDATE SKIP LOCKED) RETURNING id, payload, metadata, consumed_count, locked_until",
+			want: "UPDATE \"testing_queue\" SET locked_until = $1, started_at = CURRENT_TIMESTAMP, consumed_count = consumed_count+1 WHERE id IN (SELECT id FROM \"testing_queue\" WHERE created_at >= CURRENT_TIMESTAMP - $3::interval AND created_at < CURRENT_TIMESTAMP AND (locked_until IS NULL OR locked_until < CURRENT_TIMESTAMP) AND delayed_until < CURRENT_TIMESTAMP AND consumed_count < 3 AND processed_at IS NULL ORDER BY consumed_count ASC, created_at ASC LIMIT $2 FOR UPDATE SKIP LOCKED) RETURNING id, payload, metadata, consumed_count, locked_until",
 		},
 		{
 			name: "scn interval 12 hours abd max consumed count limit disabled",
@@ -46,12 +46,12 @@ func TestConsumer_generateQuery(t *testing.T) {
 					WithMaxConsumeCount(0),
 				},
 			},
-			want: "UPDATE \"testing_queue\" SET locked_until = $1, started_at = CURRENT_TIMESTAMP, consumed_count = consumed_count+1 WHERE id IN (SELECT id FROM \"testing_queue\" WHERE created_at >= CURRENT_TIMESTAMP - $3::interval AND created_at < CURRENT_TIMESTAMP AND (locked_until IS NULL OR locked_until < CURRENT_TIMESTAMP) AND processed_at IS NULL ORDER BY consumed_count ASC, created_at ASC LIMIT $2 FOR UPDATE SKIP LOCKED) RETURNING id, payload, metadata, consumed_count, locked_until",
+			want: "UPDATE \"testing_queue\" SET locked_until = $1, started_at = CURRENT_TIMESTAMP, consumed_count = consumed_count+1 WHERE id IN (SELECT id FROM \"testing_queue\" WHERE created_at >= CURRENT_TIMESTAMP - $3::interval AND created_at < CURRENT_TIMESTAMP AND (locked_until IS NULL OR locked_until < CURRENT_TIMESTAMP) AND delayed_until < CURRENT_TIMESTAMP AND processed_at IS NULL ORDER BY consumed_count ASC, created_at ASC LIMIT $2 FOR UPDATE SKIP LOCKED) RETURNING id, payload, metadata, consumed_count, locked_until",
 		},
 		{
 			name: "with metadata condition",
 			args: args{queueName: "testing_queue"},
-			want: "UPDATE \"testing_queue\" SET locked_until = $1, started_at = CURRENT_TIMESTAMP, consumed_count = consumed_count+1 WHERE id IN (SELECT id FROM \"testing_queue\" WHERE (locked_until IS NULL OR locked_until < CURRENT_TIMESTAMP) AND consumed_count < 3 AND processed_at IS NULL ORDER BY consumed_count ASC, created_at ASC LIMIT $2 FOR UPDATE SKIP LOCKED) RETURNING id, payload, metadata, consumed_count, locked_until",
+			want: "UPDATE \"testing_queue\" SET locked_until = $1, started_at = CURRENT_TIMESTAMP, consumed_count = consumed_count+1 WHERE id IN (SELECT id FROM \"testing_queue\" WHERE (locked_until IS NULL OR locked_until < CURRENT_TIMESTAMP) AND delayed_until < CURRENT_TIMESTAMP AND consumed_count < 3 AND processed_at IS NULL ORDER BY consumed_count ASC, created_at ASC LIMIT $2 FOR UPDATE SKIP LOCKED) RETURNING id, payload, metadata, consumed_count, locked_until",
 		},
 		{
 			name: "scanInterval 12 hours with metadata condition",
@@ -61,12 +61,12 @@ func TestConsumer_generateQuery(t *testing.T) {
 					WithHistoryLimit(12 * time.Hour),
 				},
 			},
-			want: "UPDATE \"testing_queue\" SET locked_until = $1, started_at = CURRENT_TIMESTAMP, consumed_count = consumed_count+1 WHERE id IN (SELECT id FROM \"testing_queue\" WHERE created_at >= CURRENT_TIMESTAMP - $3::interval AND created_at < CURRENT_TIMESTAMP AND (locked_until IS NULL OR locked_until < CURRENT_TIMESTAMP) AND consumed_count < 3 AND processed_at IS NULL ORDER BY consumed_count ASC, created_at ASC LIMIT $2 FOR UPDATE SKIP LOCKED) RETURNING id, payload, metadata, consumed_count, locked_until",
+			want: "UPDATE \"testing_queue\" SET locked_until = $1, started_at = CURRENT_TIMESTAMP, consumed_count = consumed_count+1 WHERE id IN (SELECT id FROM \"testing_queue\" WHERE created_at >= CURRENT_TIMESTAMP - $3::interval AND created_at < CURRENT_TIMESTAMP AND (locked_until IS NULL OR locked_until < CURRENT_TIMESTAMP) AND delayed_until < CURRENT_TIMESTAMP AND consumed_count < 3 AND processed_at IS NULL ORDER BY consumed_count ASC, created_at ASC LIMIT $2 FOR UPDATE SKIP LOCKED) RETURNING id, payload, metadata, consumed_count, locked_until",
 		},
 		{
 			name: "with negative metadata condition",
 			args: args{queueName: "testing_queue"},
-			want: "UPDATE \"testing_queue\" SET locked_until = $1, started_at = CURRENT_TIMESTAMP, consumed_count = consumed_count+1 WHERE id IN (SELECT id FROM \"testing_queue\" WHERE (locked_until IS NULL OR locked_until < CURRENT_TIMESTAMP) AND consumed_count < 3 AND processed_at IS NULL ORDER BY consumed_count ASC, created_at ASC LIMIT $2 FOR UPDATE SKIP LOCKED) RETURNING id, payload, metadata, consumed_count, locked_until",
+			want: "UPDATE \"testing_queue\" SET locked_until = $1, started_at = CURRENT_TIMESTAMP, consumed_count = consumed_count+1 WHERE id IN (SELECT id FROM \"testing_queue\" WHERE (locked_until IS NULL OR locked_until < CURRENT_TIMESTAMP) AND delayed_until < CURRENT_TIMESTAMP AND consumed_count < 3 AND processed_at IS NULL ORDER BY consumed_count ASC, created_at ASC LIMIT $2 FOR UPDATE SKIP LOCKED) RETURNING id, payload, metadata, consumed_count, locked_until",
 		},
 	}
 	for _, tt := range tests {

--- a/message.go
+++ b/message.go
@@ -29,6 +29,8 @@ type MessageOutgoing struct {
 	Metadata Metadata
 	// Payload is the message's Payload.
 	Payload json.RawMessage
+	// Delay (seconds) is the time when the message should become visible in the queue.
+	Delay int
 }
 
 // MessageIncoming is a record retrieved from table queue in Postgres

--- a/publisher_test.go
+++ b/publisher_test.go
@@ -24,7 +24,7 @@ func Test_buildInsertQuery(t *testing.T) {
 				queue:    "queue",
 				msgCount: 1,
 			},
-			want: `INSERT INTO "queue" (payload, metadata) VALUES ($1,$2) RETURNING "id"`,
+			want: `INSERT INTO "queue" (payload, metadata, delayed_until) VALUES ($1,$2,NOW()+make_interval(secs => $3)) RETURNING "id"`,
 		},
 		{
 			name: "multiple messages",
@@ -32,7 +32,7 @@ func Test_buildInsertQuery(t *testing.T) {
 				queue:    "queue",
 				msgCount: 3,
 			},
-			want: `INSERT INTO "queue" (payload, metadata) VALUES ($1,$2),($3,$4),($5,$6) RETURNING "id"`,
+			want: `INSERT INTO "queue" (payload, metadata, delayed_until) VALUES ($1,$2,NOW()+make_interval(secs => $3)),($4,$5,NOW()+make_interval(secs => $6)),($7,$8,NOW()+make_interval(secs => $9)) RETURNING "id"`,
 		},
 	}
 	for _, tt := range tests {
@@ -59,7 +59,7 @@ func TestClient_buildArgs(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				msgs: []*MessageOutgoing{
-					{Metadata: Metadata{}, Payload: nil},
+					{Metadata: Metadata{}, Payload: nil, Delay: 0},
 				},
 			},
 			want: []any{
@@ -67,6 +67,7 @@ func TestClient_buildArgs(t *testing.T) {
 				Metadata{
 					"foo": "bar",
 				},
+				0,
 			},
 		},
 		{
@@ -74,7 +75,7 @@ func TestClient_buildArgs(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				msgs: []*MessageOutgoing{
-					{Metadata: Metadata{}, Payload: nil},
+					{Metadata: Metadata{}, Payload: nil, Delay: 0},
 				},
 			},
 			want: []any{
@@ -82,6 +83,7 @@ func TestClient_buildArgs(t *testing.T) {
 				Metadata{
 					"foo": "bar",
 				},
+				0,
 			},
 		},
 	}

--- a/x/schema/queue.go
+++ b/x/schema/queue.go
@@ -14,6 +14,7 @@ func GenerateCreateTableQuery(queueName string) string {
 	(
 		id             UUID        DEFAULT gen_random_uuid() NOT NULL PRIMARY KEY,
 		created_at     TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
+		delayed_until  TIMESTAMPTZ                           NULL,
 		started_at     TIMESTAMPTZ                           NULL,
 		locked_until   TIMESTAMPTZ                           NULL,
 		processed_at   TIMESTAMPTZ                           NULL,


### PR DESCRIPTION
In some cases you may need delay message before it become available.
In my usecase I need periodicaly ask external service if state has changed in approximately 60 second intervals until I get the result (error or success).

This is similar approach to "Azure service bus - Scheduled delivery"
https://learn.microsoft.com/en-us/azure/service-bus-messaging/advanced-features-overview

I've used "Delay" instead "Schedule" because this way I can use SQL server time.
SQL and App can be on different servers with slightly different time (seconds, sometimes minutes) in case of issues with server timeSync and message queue is pretty time sensitive thing so I would say "same timesource policy" should be applied.
Schedule to exact time is still possible by calculating "seconds to" ( t2.Sub(t1) ) on App server

BTW: I'm from Prague if you want to discuss :)