### PR TITLE
chore(ci): bump actions/checkout from v3 to v4

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -57,7 +57,7 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Setting up Go in the runner
       - name: setup go


### PR DESCRIPTION
This will get rid of warning annotations added to each build:

> The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3, actions/setup-go@v4.
> For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/