### PR TITLE
chore(ci): bump actions/setup-go from v4 to v5

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -61,7 +61,7 @@ jobs:
 
       # Setting up Go in the runner
       - name: setup go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
 


### PR DESCRIPTION
This will get rid of the warning annotations added to each build:

> The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3, actions/setup-go@v4.
> For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/