### PR TITLE
chore(ci): remove PostgreSQL 11 from build matrix due to EOL

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,7 +24,7 @@ jobs:
         # version must be string, otherwise it will be converted to float
         # and the trailing zero will be removed. 1.20 -> 1.2
         go-version: [ "1.22", "1.23" ]
-        postgres-version: [ 16, 15, 14, 13, 12, 11 ]
+        postgres-version: [ 16, 15, 14, 13, 12 ]
     # Ensure that all combinations of Go and Postgres versions will run
     continue-on-error: true
 


### PR DESCRIPTION
PostgreSQL 11 already reached EOL on 2023-11-09: https://endoflife.date/postgresql