### PR TITLE
chore(ci): add PostgreSQL 17 to build matrix

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,7 +24,7 @@ jobs:
         # version must be string, otherwise it will be converted to float
         # and the trailing zero will be removed. 1.20 -> 1.2
         go-version: [ "1.22", "1.23" ]
-        postgres-version: [ 16, 15, 14, 13, 12, 11 ]
+        postgres-version: [ 17, 16, 15, 14, 13, 12, 11 ]
     # Ensure that all combinations of Go and Postgres versions will run
     continue-on-error: true
 


### PR DESCRIPTION
PostgreSQL 17 has been released and should be tested.

- https://www.postgresql.org/about/news/postgresql-17-released-2936/
- https://www.postgresql.org/docs/17/release-17.html