### PR TITLE
feat: add (*MessageIncoming).SetTimeout/SetDeadline methods

### DIFF
--- a/message_test.go
+++ b/message_test.go
@@ -1,7 +1,11 @@
 package pgq
 
 import (
+	"context"
 	"testing"
+	"time"
+
+	"go.dataddo.com/pgq/internal/require"
 )
 
 func TestMessageIncoming_LastAttempt(t *testing.T) {
@@ -57,4 +61,20 @@ func TestMessageIncoming_LastAttempt(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMessageIncoming_SetDeadline(t *testing.T) {
+	m := &MessageIncoming{
+		Deadline: time.Date(9999, 0, 0, 0, 0, 0, 0, time.UTC),
+		updateLockedUntilFn: func(ctx context.Context, t time.Time) error {
+			return nil
+		},
+	}
+	ctx := context.Background()
+	ctx, err := m.SetDeadline(ctx, time.Now().Add(time.Second))
+	require.NoError(t, err)
+	ctx, err = m.SetDeadline(ctx, time.Now())
+	require.NoError(t, err)
+	ctx, err = m.SetDeadline(ctx, time.Now())
+	require.Error(t, err)
 }


### PR DESCRIPTION
The methods serve as stricter counterpart to
`WithLockDuration(d time.Duration) ConsumerOption`. If message metadata contain shorter timeout, you can decrease lock time. Without this, you can only limit `context.Context` deadline, but in a case of non-graceful shutdown, the message would stay locked. With this, you can use lock duration option as an upper limit, and use these methods for a fine-tuning.